### PR TITLE
Remove omitted filenames from each chunk's "files" property

### DIFF
--- a/__tests__/css-entry-array.test.js
+++ b/__tests__/css-entry-array.test.js
@@ -6,6 +6,7 @@ const optionsSass = require('./fixtures/css-array-entry/webpack.config.sass.js')
 const optionsLess = require('./fixtures/css-array-entry/webpack.config.less.js');
 const dirPath = path.join(__dirname, './fixtures/css-array-entry/dir');
 const fileShouldNotExist = require('./utils/file-should-not-exist.js');
+const chunkShouldNotContainFile = require('./utils/chunk-should-not-contain-file.js');
 
 describe('Array of CSS Dependencies as Entry', () => {
 	beforeEach(done => {
@@ -15,8 +16,9 @@ describe('Array of CSS Dependencies as Entry', () => {
 	});
 
 	it('JS entry should not exist', done => {
-		webpack(options, () => {
+		webpack(options, (err, stats) => {
 			fileShouldNotExist(dirPath, '/a.js');
+			chunkShouldNotContainFile(stats, 'a', 'a.js');
 			done();
 		});
 	});
@@ -25,32 +27,36 @@ describe('Array of CSS Dependencies as Entry', () => {
 		const optionSourceMap = Object.assign({}, options);
 		optionSourceMap.devtool = 'source-map';
 
-		webpack(optionSourceMap, () => {
+		webpack(optionSourceMap, (err, stats) => {
 			fileShouldNotExist(dirPath, '/a.js.map');
+			chunkShouldNotContainFile(stats, 'a', 'a.js.map');
 			done();
 		});
 	});
 
 	it('JS entry should not exist w/ sass', done => {
-		webpack(optionsSass, () => {
+		webpack(optionsSass, (err, stats) => {
 			fileShouldNotExist(dirPath, '/s.js');
+			chunkShouldNotContainFile(stats, 's', 's.js');
 			done();
 		});
 	});
 
 	it('JS entry source map should not exist w/ sass', done => {
-		const optionSourceMap = Object.assign({}, options);
+		const optionSourceMap = Object.assign({}, optionsSass);
 		optionSourceMap.devtool = 'source-map';
 
-		webpack(optionSourceMap, () => {
+		webpack(optionSourceMap, (err, stats) => {
 			fileShouldNotExist(dirPath, '/s.js.map');
+			chunkShouldNotContainFile(stats, 's', 's.js.map');
 			done();
 		});
 	});	
 
 	it('JS entry should not exist w/ less', done => {
-		webpack(optionsLess, () => {
+		webpack(optionsLess, (err, stats) => {
 			fileShouldNotExist(dirPath, '/l.js');
+			chunkShouldNotContainFile(stats, 'l', 'l.js');
 			done();
 		});
 	});
@@ -59,8 +65,9 @@ describe('Array of CSS Dependencies as Entry', () => {
 		const optionSourceMap = Object.assign({}, optionsLess);
 		optionSourceMap.devtool = 'source-map';
 
-		webpack(optionSourceMap, () => {
+		webpack(optionSourceMap, (err, stats) => {
 			fileShouldNotExist(dirPath, '/l.js.map');
+			chunkShouldNotContainFile(stats, 'l', 'l.js.map');
 			done();
 		});
 	});	

--- a/__tests__/js-file-entry.test.js
+++ b/__tests__/js-file-entry.test.js
@@ -5,6 +5,7 @@ const options = require('./fixtures/js-file-entry/webpack.config.js');
 const optionsLess = require('./fixtures/js-file-entry/webpack.config.less.js');
 const optionsSass = require('./fixtures/js-file-entry/webpack.config.sass.js');
 const fileShouldNotExist = require('./utils/file-should-not-exist.js');
+const chunkShouldNotContainFile = require('./utils/chunk-should-not-contain-file.js');
 const dirPath = path.join(__dirname, './fixtures/js-file-entry/dir');
 
 describe('JS file with CSS Dependencies as Entry', () => {
@@ -15,8 +16,9 @@ describe('JS file with CSS Dependencies as Entry', () => {
 	});
 
 	it('JS entry file should not exist', done => {
-		webpack(options, () => {
+		webpack(options, (err, stats) => {
 			fileShouldNotExist(dirPath, '/b.js');
+			chunkShouldNotContainFile(stats, 'b', 'b.js');
 			done();
 		});
 	});
@@ -25,15 +27,17 @@ describe('JS file with CSS Dependencies as Entry', () => {
 		const optionSourceMap = Object.assign({}, options);
 		optionSourceMap.devtool = 'source-map';
 
-		webpack(optionSourceMap, () => {
+		webpack(optionSourceMap, (err, stats) => {
 			fileShouldNotExist(dirPath, '/b.js.map');
+			chunkShouldNotContainFile(stats, 'b', 'b.js.map');
 			done();
 		});
 	});
 
 	it('JS entry file should not exist w/ less', done => {
-		webpack(optionsLess, () => {
+		webpack(optionsLess, (err, stats) => {
 			fileShouldNotExist(dirPath, '/l.js');
+			chunkShouldNotContainFile(stats, 'l', 'l.js');
 			done();
 		});
 	});
@@ -42,15 +46,17 @@ describe('JS file with CSS Dependencies as Entry', () => {
 		const optionSourceMap = Object.assign({}, optionsLess);
 		optionSourceMap.devtool = 'source-map';
 
-		webpack(optionSourceMap, () => {
+		webpack(optionSourceMap, (err, stats) => {
 			fileShouldNotExist(dirPath, '/l.js.map');
+			chunkShouldNotContainFile(stats, 'l', 'l.js.map');
 			done();
 		});
 	});	
 
 	it('JS entry file should not exist w/ sass', done => {
-		webpack(optionsSass, () => {
+		webpack(optionsSass, (err, stats) => {
 			fileShouldNotExist(dirPath, '/s.js');
+			chunkShouldNotContainFile(stats, 's', 's.js');
 			done();
 		});
 	});
@@ -59,8 +65,9 @@ describe('JS file with CSS Dependencies as Entry', () => {
 		const optionSourceMap = Object.assign({}, optionsSass);
 		optionSourceMap.devtool = 'source-map';
 
-		webpack(optionSourceMap, () => {
+		webpack(optionSourceMap, (err, stats) => {
 			fileShouldNotExist(dirPath, '/s.js.map');
+			chunkShouldNotContainFile(stats, 's', 's.js.map');
 			done();
 		});
 	});		

--- a/__tests__/options.test.js
+++ b/__tests__/options.test.js
@@ -4,6 +4,7 @@ const webpack = require('webpack');
 const OmitJSforCSSPlugin = require('../src/index.js');
 const fileShouldExist = require('./utils/file-should-exist.js');
 const fileShouldNotExist = require('./utils/file-should-not-exist.js');
+const chunkShouldContainFile = require('./utils/chunk-should-contain-file.js');
 const previewOptions = require('./fixtures/options/preview/webpack.config.js');
 const previewDirPath = path.join(__dirname, '/fixtures/options/preview/dir');
 const verboseOptions = require('./fixtures/options/verbose/webpack.config.js');
@@ -61,9 +62,11 @@ describe('Options', () => {
 		});
 
 		it('should not omit files', done => {
-			webpack(previewOptions, () => {
+			webpack(previewOptions, (err, stats) => {
 				fileShouldExist(previewDirPath, 'b.js');
+				chunkShouldContainFile(stats, 'b', 'b.js');
 				fileShouldExist(previewDirPath, 'b.js.map');
+				chunkShouldContainFile(stats, 'b', 'b.js.map');
 				done();
 			});
 		});

--- a/__tests__/should-not-omit.test.js
+++ b/__tests__/should-not-omit.test.js
@@ -2,6 +2,7 @@ const webpack = require('webpack');
 const path = require('path');
 const rimraf = require('rimraf');
 const fileShouldExist = require('./utils/file-should-exist.js');
+const chunkShouldContainFile = require('./utils/chunk-should-contain-file.js');
 // Internal
 const internalOptions = require('./fixtures/should-not-omit/internal-dep/webpack.config.js');
 const internalDirPath = path.join(__dirname, './fixtures/should-not-omit/internal-dep/dir');
@@ -26,9 +27,11 @@ describe("JS Dependencies that shouldn't be omitted", () => {
 		});
 
 		it('should not omit JS with internal deps', done => {
-			webpack(internalOptions, () => {
+			webpack(internalOptions, (err, stats) => {
 				fileShouldExist(internalDirPath, '/b.js');
+				chunkShouldContainFile(stats, 'b', 'b.js');
 				fileShouldExist(internalDirPath, '/b.js.map');
+				chunkShouldContainFile(stats, 'b', 'b.js.map');
 				done();
 			});
 		});
@@ -42,17 +45,21 @@ describe("JS Dependencies that shouldn't be omitted", () => {
 		});
 
 		it('should not omit JS with external dependencies', done => {
-			webpack(externalOptions, () => {
+			webpack(externalOptions, (err, stats) => {
 				fileShouldExist(externalDirPath, '/c.js');
+				chunkShouldContainFile(stats, 'c', 'c.js');
 				fileShouldExist(externalDirPath, '/c.js.map');
+				chunkShouldContainFile(stats, 'c', 'c.js.map');
 				done();
 			});
 		});
 
 		it('should not omit JS with an array of external dependencies', done => {
-			webpack(externalOptionsArr, () => {
+			webpack(externalOptionsArr, (err, stats) => {
 				fileShouldExist(externalDirPath, '/e.js');
+				chunkShouldContainFile(stats, 'e', 'e.js');
 				fileShouldExist(externalDirPath, '/e.js.map');
+				chunkShouldContainFile(stats, 'e', 'e.js.map');
 				done();
 			});
 		});
@@ -66,21 +73,29 @@ describe("JS Dependencies that shouldn't be omitted", () => {
 		});
 
 		it('should not omit JS with external and internal dependencies', done => {
-			webpack(extInOptions, () => {
+			webpack(extInOptions, (err, stats) => {
 				fileShouldExist(extInDirPath, '/f.js');
+				chunkShouldContainFile(stats, 'f', 'f.js');
 				fileShouldExist(extInDirPath, '/f.js.map');
+				chunkShouldContainFile(stats, 'f', 'f.js.map');
 				fileShouldExist(extInDirPath, '/f.css');
+				chunkShouldContainFile(stats, 'f', 'f.css');
 				fileShouldExist(extInDirPath, '/f.css.map');
+				chunkShouldContainFile(stats, 'f', 'f.css.map');
 				done();
 			});
 		});
 		
 		it('should not omit JS with external and internal dependencies when entry is array', done => {
-			webpack(extInArrOptions, () => {
+			webpack(extInArrOptions, (err, stats) => {
 				fileShouldExist(extInDirPath, '/j.js');
+				chunkShouldContainFile(stats, 'j', 'j.js');
 				fileShouldExist(extInDirPath, '/j.js.map');
+				chunkShouldContainFile(stats, 'j', 'j.js.map');
 				fileShouldExist(extInDirPath, '/j.css');
+				chunkShouldContainFile(stats, 'j', 'j.css');
 				fileShouldExist(extInDirPath, '/j.css.map');
+				chunkShouldContainFile(stats, 'j', 'j.css.map');
 				done();
 			});
 		});		
@@ -94,11 +109,15 @@ describe("JS Dependencies that shouldn't be omitted", () => {
 		});
 
 		it('should not omit JS with mixed dependencies', done => {
-			webpack(mixedOptions, () => {
+			webpack(mixedOptions, (err, stats) => {
 				fileShouldExist(mixedDirPath, '/d.js');
+				chunkShouldContainFile(stats, 'd', 'd.js');
 				fileShouldExist(mixedDirPath, '/d.js.map');
+				chunkShouldContainFile(stats, 'd', 'd.js.map');
 				fileShouldExist(mixedDirPath, '/d.css');
+				chunkShouldContainFile(stats, 'd', 'd.css');
 				fileShouldExist(mixedDirPath, '/d.css.map');
+				chunkShouldContainFile(stats, 'd', 'd.css.map');
 				done();
 			});
 		});

--- a/__tests__/utils/chunk-should-contain-file.js
+++ b/__tests__/utils/chunk-should-contain-file.js
@@ -1,0 +1,13 @@
+/**
+ * @param stats {String} The webpack compilation stats object
+ * @param chunkName {String} The name of a chunk
+ * @param fileName {String} The name of a file which should be contained in the chunk
+ */
+module.exports = function(stats, chunkName, fileName) {
+	const chunks = stats.compilation.namedChunks;
+	expect(typeof chunkName).toEqual('string');
+	const chunk = chunks.get(chunkName);
+	expect(typeof chunk).toEqual('object');
+	expect(typeof fileName).toEqual('string');
+	expect(chunk.files).toContain(fileName);
+}

--- a/__tests__/utils/chunk-should-not-contain-file.js
+++ b/__tests__/utils/chunk-should-not-contain-file.js
@@ -1,0 +1,13 @@
+/**
+ * @param stats {String} The webpack compilation stats object
+ * @param chunkName {String} The name of a chunk
+ * @param fileName {String} The name of a file which should not be contained in the chunk
+ */
+module.exports = function(stats, chunkName, fileName) {
+	const chunks = stats.compilation.namedChunks;
+	expect(typeof chunkName).toEqual('string');
+	const chunk = chunks.get(chunkName);
+	expect(typeof chunk).toEqual('object');
+	expect(typeof fileName).toEqual('string');
+	expect(chunk.files).not.toContain(fileName);
+}

--- a/src/index.js
+++ b/src/index.js
@@ -22,15 +22,17 @@ function OmitJSforCSSPlugin(options) {
 
 /**
  * @function omitFiles
- * @param {Object} omitted - The omitted file's details
+ * @param {String} filename - The omitted file name
+ * @param {Object} chunk - The chunk containing the file to omit
  * @param {Object} compilation
  */
-OmitJSforCSSPlugin.prototype.omitFiles = function (omitted, compilation) {
+OmitJSforCSSPlugin.prototype.omitFiles = function (filename, chunk, compilation) {
 	if (this.options.preview) {
-		console.log(`PREVIEW File to be omitted for ${omitted.chunkName} : ${omitted.filename}`);
+		console.log(`PREVIEW File to be omitted for ${chunk.name} : ${filename}`);
 	} else {
-		this.options.verbose && console.log(`File omitted for ${omitted.chunkName} : ${omitted.filename}`);
-		delete compilation.assets[omitted.filename];
+		this.options.verbose && console.log(`File omitted for ${chunk.name} : ${filename}`);
+		chunk.files = chunk.files.filter(name => name !== filename);
+		delete compilation.assets[filename];
 	}
 };
 
@@ -69,12 +71,7 @@ OmitJSforCSSPlugin.prototype.findOmissibleFiles = function (compilation) {
 			// If all dependencies of this entry were CSS, then a JS version of this file will be created
 			// This js file will be empty due to extract-text-webpack-plugin
 			if (assetTypeCount.css > 0 && assetTypeCount.internal === 0 && (/\.(js)$/i.test(filename) || /\.(js).map$/i.test(filename))) {
-				let omitted = {
-					filename: filename,
-					chunkName: chunk.name
-				};
-
-				this.omitFiles(omitted, compilation);
+				this.omitFiles(filename, chunk, compilation);
 			}
 		});
 	});


### PR DESCRIPTION
When a file is omitted from `compilation.assets`, its filename still
referenced by the chunk it belongs to. This can confuse other webpack
plugins that reference `chunk.files`. An example is `html-webpack-plugin`,
which will insert a script tag for the omitted asset because its filename
is still in `chunk.files`.

This commit removes the omitted filename from the chunk it belongs to,
in addition to removing it from the compilation's assets.

Unrelated, this PR fixes the spec "Array of CSS Dependencies as Entry -> JS entry source map should not exist w/ sass" which was compiling its fixture with the wrong webpack config, causing it to never fail.